### PR TITLE
Generate more random Applicative values to put our functions in

### DIFF
--- a/hedgehog-checkers/src/Hedgehog/Checkers/Classes.hs
+++ b/hedgehog-checkers/src/Hedgehog/Checkers/Classes.hs
@@ -169,9 +169,9 @@ applicative gen gena genb genc = do
         applicativeComposition = do
           fa <- forAll gen
           fbc' <- ordFuncWtf genb genc
-          let fbc = fmap (const fbc') fa
+          fbc <- fmap (const fbc') <$> forAll gen
           fab' <- ordFuncWtf gena genb
-          let fab = fmap (const fab') fa
+          fab <- fmap (const fab') <$> forAll gen
           (pure (.) <*> fbc <*> fab <*> fa) === (fbc <*> (fab <*> fa))
 
         applicativeHomomorphism = do
@@ -185,7 +185,7 @@ applicative gen gena genb genc = do
           a <- forAll gena
           fa <- forAll gen
           fab' <- ordFuncWtf gena genb
-          let fab = fmap (const fab') fa
+          fab <- fmap (const fab') <$> forAll gen
           (fab <*> pure a) === (pure ($ a) <*> fab)
 
         applicativeFunctor = do


### PR DESCRIPTION
Previously both the `f a` and the `f (a -> b)` would have had the same shape
(Eg. both `Just` or both `Nothing`)